### PR TITLE
Add "object replacement character" to defaults

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
         '\u205F', // medium mathematical space
         '\u3000', // ideographic space
         '\uFEFF', // zero width no-break space
+        '\uFFFC', // object replacement character
 
         // others
         '\u037E', // greek question mark


### PR DESCRIPTION
This char can creep into text copied from certain developer tools