### PR TITLE
Updated to support VS Code for the Web

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,17 +1,31 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-    "version": "0.1.0",
+    "version": "0.2.0",
     "configurations": [
         {
             "name": "Launch Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}"
+            ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
             "preLaunchTask": "npm"
-        }
+        },
+        {
+            "name": "Launch Web Extension",
+            "type": "pwa-extensionHost",
+            "debugWebWorkerHost": true,
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}",
+                "--extensionDevelopmentKind=web"
+            ],
+            "sourceMaps": true,
+            "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+            "preLaunchTask": "npm"
+          }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,16 +8,10 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
     // we want to run npm
     "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
 
     // we run the custom script "compile" as defined in package.json
     "args": ["run", "compile", "--loglevel", "silent"],
@@ -26,5 +20,24 @@
     "isBackground": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "problemMatcher": "$tsc-watch",
+    "tasks": [
+        {
+            "label": "npm",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,66 @@
+{
+    "name": "highlight-bad-chars",
+    "version": "0.0.1",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "highlight-bad-chars",
+            "version": "0.0.1",
+            "license": "MIT",
+            "devDependencies": {
+                "@types/node": "^16.10.2",
+                "@types/vscode": "^1.59.0",
+                "typescript": "^4.4.3"
+            },
+            "engines": {
+                "vscode": "^1.59.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "16.10.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.2.tgz",
+            "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==",
+            "dev": true
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
+            "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
+            "dev": true
+        },
+        "node_modules/typescript": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@types/node": {
+            "version": "16.10.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.2.tgz",
+            "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==",
+            "dev": true
+        },
+        "@types/vscode": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
+            "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "icon": "icon.png",
     "engines": {
-        "vscode": "^1.11.0"
+        "vscode": "^1.59.0"
     },
     "categories": [
         "Other"
@@ -19,6 +19,7 @@
         "*"
     ],
     "main": "./out/src/extension",
+    "browser": "./out/src/extension",
     "contributes": {
         "configuration": {
             "type": "object",
@@ -52,14 +53,11 @@
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "compile": "tsc -watch -p ./"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "@types/node": "^16.10.2",
+        "@types/vscode": "^1.59.0",
+        "typescript": "^4.4.3"
     }
 }


### PR DESCRIPTION
This PR should update the extension so it is a web-enabled extension: https://code.visualstudio.com/api/extension-guides/web-extensions This means it will work on github.dev too!

I'm a big fan of this extension and I use github.dev extensively, so this will help :) 

PS: I had to update all dependencies and do some more cleanup of package.json or this wasn't building anymore.