### PR TITLE
Highlight dangerous characters per CVE-2021-42574

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "highlight-bad-chars" extension will be documented in
 
 ## Unreleased
 
+- [feat] highlight dangerous characters that could be exploited per [Trojan Source](https://trojansource.codes/) (CVE-2021-42574)
 - [feat] bundle extension with Webpack for better support for unpkg and browser extension host; the extension always runs in the web extension host now
 - [feat] add Github Actions running tests & styles
 - [feat] add Jest Snapshot testing

--- a/src/bad-characters.ts
+++ b/src/bad-characters.ts
@@ -48,18 +48,23 @@ export default [
     '\uFEFF', // zero width no-break space
     '\uFFFC', // object replacement character
 
-    // Dangerous characters per CVE-2021-42574
-    // https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
-    // More details: https://www.openwall.com/lists/oss-security/2021/11/01/1
+    // Dangerous characters per Trojan Sources
+    // https://trojansource.codes
+    // Contains additional characters listed on https://access.redhat.com/security/vulnerabilities/RHSB-2021-007
+    '\u061C',
+    '\u200E',
+    '\u200F',
     '\u202A',
     '\u202B',
+    '\u202C',
     '\u202D',
     '\u202E',
     '\u2066',
     '\u2067',
     '\u2068',
-    '\u202C',
     '\u2069',
+    '\u200B',
+    '\u200C',
 
     // control characters
     `\x00`, // NUL

--- a/src/bad-characters.ts
+++ b/src/bad-characters.ts
@@ -48,6 +48,19 @@ export default [
     '\uFEFF', // zero width no-break space
     '\uFFFC', // object replacement character
 
+    // Dangerous characters per CVE-2021-42574
+    // https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
+    // More details: https://www.openwall.com/lists/oss-security/2021/11/01/1
+    '\u202A',
+    '\u202B',
+    '\u202D',
+    '\u202E',
+    '\u2066',
+    '\u2067',
+    '\u2068',
+    '\u202C',
+    '\u2069',
+
     // control characters
     `\x00`, // NUL
     `\x01`, // SOH

--- a/src/bad-characters.ts
+++ b/src/bad-characters.ts
@@ -64,7 +64,6 @@ export default [
     '\u2068',
     '\u2069',
     '\u200B',
-    '\u200C',
 
     // control characters
     `\x00`, // NUL


### PR DESCRIPTION
Adds to the list of bad characters those that are used for the [Trojan Source](https://trojansource.codes/) attack ([CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574))